### PR TITLE
Remove errant 8501 mapping

### DIFF
--- a/lib/tzip/values/mountain.rb
+++ b/lib/tzip/values/mountain.rb
@@ -2,6 +2,6 @@ module TZip
   ZONINGS[:mountain] = %w{577}
   ZONINGS[:mountain] += %w{59}
   ZONINGS[:mountain] += %w{798 799}
-  ZONINGS[:mountain] += %w{80 81 82 83 831 84 8501 87 88}
+  ZONINGS[:mountain] += %w{80 81 82 83 831 84 87 88}
   ZONINGS[:mountain] += %w{979}
 end


### PR DESCRIPTION
All 8501 zipcodes fall within the already-existing 85 mapping in `arizona.rb`. This entry was causing errors.